### PR TITLE
fix(docker): migrate Dockerfile.konflux to ubi9-minimal for FIPS compliance

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -1,6 +1,6 @@
 # Simplified Dockerfile for model metadata collection
 # Since models-catalog.yaml is now checked in by CI/CD, we only need to copy the files
-FROM registry.access.redhat.com/ubi9-micro:latest
+FROM registry.access.redhat.com/ubi9-minimal:latest
 
 # Create directory for mounting by other applications
 RUN mkdir -p /app/data


### PR DESCRIPTION
Resolved FIPS check-payload compliance validation failures in rhoaieng-38123.

Issue: The ubi9-micro base image lacks openssl package, causing FIPS compliance validation to fail during check-payload scans. The minimal container footprint of ubi9-micro does not include the necessary cryptographic libraries required for FIPS 140-2 certification validation.

Solution: Migrated Dockerfile.konflux from registry.access.redhat.com/ubi9-micro to registry.access.redhat.com/ubi9-minimal base image. The ubi9-minimal image includes openssl and other essential packages needed for FIPS compliance while maintaining a reasonably small container footprint.


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work