### PR TITLE
AIPCC-20037: Add Tekton PaC pipelines for Konflux builds

### DIFF
--- a/.tekton/ai-hub-catalog-ubi9-on-pull-request.yaml
+++ b/.tekton/ai-hub-catalog-ubi9-on-pull-request.yaml
@@ -1,0 +1,72 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/model-metadata-collection/-/tree/{{revision}}
+    build.appstudio.redhat.com/commit_sha: "{{revision}}"
+    build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
+    build.appstudio.redhat.com/target_branch: "{{target_branch}}"
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request" && target_branch == "main" && (
+          ".tekton/ai-hub-catalog-ubi9-on-pull-request.yaml".pathChanged() ||
+          "Dockerfile.konflux".pathChanged() ||
+          "data/***".pathChanged()
+      )
+  labels:
+    appstudio.openshift.io/application: ai-hub
+    appstudio.openshift.io/component: ai-hub-catalog-ubi9
+    pipelines.appstudio.openshift.io/type: build
+  name: ai-hub-catalog-ubi9-on-pull-request
+  namespace: ai-tenant
+spec:
+  params:
+  - name: git-url
+    value: "{{source_url}}"
+  - name: revision
+    value: "{{revision}}"
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ai-tenant/ai-hub/ai-hub-catalog-ubi9:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: dockerfile
+    value: Dockerfile.konflux
+  - name: path-context
+    value: .
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
+    - linux-m2xlarge/arm64
+  - name: labels
+    value:
+    - name=ai-hub/catalog-ubi9
+    - com.redhat.component=ai-hub/catalog-ubi9-container
+    - cpe=cpe:/a:redhat:openshift_ai:3.6::el9
+  pipelineRef:
+    params:
+    - name: org
+      value: redhat
+    - name: repo
+      value: rhel-ai/konflux-data
+    - name: scmType
+      value: gitlab
+    - name: serverURL
+      value: https://gitlab.com
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipelines/full-container.yaml
+    - name: token
+      value: pipelines-as-code-secret
+    - name: tokenKey
+      value: password
+    resolver: git
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-ai-hub-catalog-ubi9
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: "{{ git_auth_secret }}"

--- a/.tekton/ai-hub-catalog-ubi9-on-push.yaml
+++ b/.tekton/ai-hub-catalog-ubi9-on-push.yaml
@@ -1,0 +1,69 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/model-metadata-collection/-/tree/{{revision}}
+    build.appstudio.redhat.com/commit_sha: "{{revision}}"
+    build.appstudio.redhat.com/target_branch: "{{target_branch}}"
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push" && target_branch == "main" && (
+          ".tekton/ai-hub-catalog-ubi9-on-push.yaml".pathChanged() ||
+          "Dockerfile.konflux".pathChanged() ||
+          "data/***".pathChanged()
+      )
+  labels:
+    appstudio.openshift.io/application: ai-hub
+    appstudio.openshift.io/component: ai-hub-catalog-ubi9
+    pipelines.appstudio.openshift.io/type: build
+  name: ai-hub-catalog-ubi9-on-push
+  namespace: ai-tenant
+spec:
+  params:
+  - name: git-url
+    value: "{{source_url}}"
+  - name: revision
+    value: "{{revision}}"
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ai-tenant/ai-hub/ai-hub-catalog-ubi9:{{revision}}
+  - name: dockerfile
+    value: Dockerfile.konflux
+  - name: path-context
+    value: .
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
+    - linux-m2xlarge/arm64
+  - name: labels
+    value:
+    - name=ai-hub/catalog-ubi9
+    - com.redhat.component=ai-hub/catalog-ubi9-container
+    - cpe=cpe:/a:redhat:openshift_ai:3.6::el9
+  pipelineRef:
+    params:
+    - name: org
+      value: redhat
+    - name: repo
+      value: rhel-ai/konflux-data
+    - name: scmType
+      value: gitlab
+    - name: serverURL
+      value: https://gitlab.com
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipelines/full-container.yaml
+    - name: token
+      value: pipelines-as-code-secret
+    - name: tokenKey
+      value: password
+    resolver: git
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-ai-hub-catalog-ubi9
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: "{{ git_auth_secret }}"


### PR DESCRIPTION
AIPCC-20037

Adds `.tekton/` pipeline definitions for the `ai-hub-catalog-ubi9` Konflux component in `ai-tenant`.

- `ai-hub-catalog-ubi9-on-pull-request.yaml` — triggered on PRs to `main`
- `ai-hub-catalog-ubi9-on-push.yaml` — triggered on pushes to `main`

Builds all 4 architectures (x86_64, ppc64le, s390x, arm64) using `Dockerfile.konflux`.

Signed-off-by: Jose Angel Morena <jmorenas@redhat.com>