### PR TITLE
chore: update ocp mcp version to 0.4 (cherry-pick to rhoai-3.5)

### DIFF
--- a/data/redhat-mcp-servers-catalog.yaml
+++ b/data/redhat-mcp-servers-catalog.yaml
@@ -28,13 +28,16 @@ mcp_servers:
         ## Configuration
         The server can be configured via TOML file or command-line flags.
         Default toolsets: `core`, `config` (with `read_only: true`).
-        Additional toolsets: `helm`, `kubevirt`, `observability`, `ossm`, `netedge` (OCP).
+        Additional toolsets: `cluster-diagnostics`, `cni-diagnostics`, `helm`,
+        `kubevirt`, `netedge`, `netobserv`, `oadp`, `observability/metrics`,
+        `observability/logs`, `observability/otelcol`, `observability/traces`,
+        `openshift/mustgather` `ossm`, `ovn-kubernetes`, `tekton` (OCP).
 
         The tools listed below reflect the default configuration. The actual set of
         available tools depends on configuration — toolsets can be enabled or disabled,
         and individual tools within a toolset can be filtered using allow/deny lists.
-        See [Tool Filtering](https://github.com/openshift/openshift-mcp-server/blob/release-0.2.0/docs/configuration.md#tool-filtering) for details.
-      version: latest
+        See [Tool Filtering](https://github.com/openshift/openshift-mcp-server/blob/release-0.4/docs/configuration.md#tool-filtering) for details.
+      version: "0.4"
       transports:
         - http
         - sse
@@ -238,9 +241,9 @@ mcp_servers:
           accessType: read_only
           parameters: []
       artifacts:
-        - uri: oci://registry.redhat.io/openshift-mcp-tech-preview/openshift-mcp-server-rhel9:0.3
-          createTimeSinceEpoch: "1777874265000"
-          lastUpdateTimeSinceEpoch: "1777874266000"
+        - uri: oci://registry.redhat.io/openshift-mcp-tech-preview/openshift-mcp-server-rhel9:0.4
+          createTimeSinceEpoch: "1785344615000"
+          lastUpdateTimeSinceEpoch: "1785344616000"
       runtimeMetadata:
         defaultArgs:
             - --config
@@ -291,7 +294,7 @@ mcp_servers:
             metadataType: MetadataStringValue
             string_value: "redHatSupported"
       createTimeSinceEpoch: "1753228800000"
-      lastUpdateTimeSinceEpoch: "1777874266000"
+      lastUpdateTimeSinceEpoch: "1785344616000"
     - name: aap-mcp-server
       provider: Red Hat
       license: apache-2.0
@@ -379,8 +382,8 @@ mcp_servers:
           parameters: []
       artifacts:
         - uri: oci://registry.redhat.io/ansible-automation-platform-tech-preview/mcp-server-rhel9:latest
-          createTimeSinceEpoch: "1779783371000"
-          lastUpdateTimeSinceEpoch: "1779783372000"
+          createTimeSinceEpoch: "1783953394000"
+          lastUpdateTimeSinceEpoch: "1783953395000"
       runtimeMetadata:
         defaultPort: 3000
         mcpPath: /mcp
@@ -449,7 +452,7 @@ mcp_servers:
             metadataType: MetadataStringValue
             string_value: "redHatSupported"
       createTimeSinceEpoch: "1769990400000"
-      lastUpdateTimeSinceEpoch: "1779783372000"
+      lastUpdateTimeSinceEpoch: "1783953395000"
     - name: insights-mcp-server
       provider: Red Hat
       license: apache-2.0
@@ -650,8 +653,8 @@ mcp_servers:
           parameters: []
       artifacts:
         - uri: oci://ghcr.io/redhatinsights/red-hat-lightspeed-mcp:latest
-          createTimeSinceEpoch: "1782220479000"
-          lastUpdateTimeSinceEpoch: "1782220479000"
+          createTimeSinceEpoch: "1785334732000"
+          lastUpdateTimeSinceEpoch: "1785334732000"
       runtimeMetadata:
         defaultPort: 8000
         mcpPath: /mcp
@@ -712,4 +715,4 @@ mcp_servers:
             metadataType: MetadataStringValue
             string_value: "redHatSupported"
       createTimeSinceEpoch: "1741996800000"
-      lastUpdateTimeSinceEpoch: "1782220479000"
+      lastUpdateTimeSinceEpoch: "1785334732000"

--- a/input/mcp_servers/redhat/aap-mcp-server.yaml
+++ b/input/mcp_servers/redhat/aap-mcp-server.yaml
@@ -85,8 +85,8 @@ tools:
       parameters: []
 artifacts:
     - uri: oci://registry.redhat.io/ansible-automation-platform-tech-preview/mcp-server-rhel9:latest
-      createTimeSinceEpoch: "1779783371000"
-      lastUpdateTimeSinceEpoch: "1779783372000"
+      createTimeSinceEpoch: "1783953394000"
+      lastUpdateTimeSinceEpoch: "1783953395000"
 runtimeMetadata:
     defaultPort: 3000
     mcpPath: /mcp
@@ -152,4 +152,4 @@ customProperties:
         metadataType: MetadataStringValue
         string_value: ""
 createTimeSinceEpoch: "1769990400000"
-lastUpdateTimeSinceEpoch: "1779783372000"
+lastUpdateTimeSinceEpoch: "1783953395000"

--- a/input/mcp_servers/redhat/insights-mcp-server.yaml
+++ b/input/mcp_servers/redhat/insights-mcp-server.yaml
@@ -198,8 +198,8 @@ tools:
       parameters: []
 artifacts:
     - uri: oci://ghcr.io/redhatinsights/red-hat-lightspeed-mcp:latest
-      createTimeSinceEpoch: "1782220479000"
-      lastUpdateTimeSinceEpoch: "1782220479000"
+      createTimeSinceEpoch: "1785334732000"
+      lastUpdateTimeSinceEpoch: "1785334732000"
 runtimeMetadata:
     defaultPort: 8000
     mcpPath: /mcp
@@ -257,4 +257,4 @@ customProperties:
         metadataType: MetadataStringValue
         string_value: ""
 createTimeSinceEpoch: "1741996800000"
-lastUpdateTimeSinceEpoch: "1782220479000"
+lastUpdateTimeSinceEpoch: "1785334732000"

--- a/input/mcp_servers/redhat/openshift-mcp-server.yaml
+++ b/input/mcp_servers/redhat/openshift-mcp-server.yaml
@@ -26,13 +26,16 @@ readme: |-
     ## Configuration
     The server can be configured via TOML file or command-line flags.
     Default toolsets: `core`, `config` (with `read_only: true`).
-    Additional toolsets: `helm`, `kubevirt`, `observability`, `ossm`, `netedge` (OCP).
+    Additional toolsets: `cluster-diagnostics`, `cni-diagnostics`, `helm`,
+    `kubevirt`, `netedge`, `netobserv`, `oadp`, `observability/metrics`,
+    `observability/logs`, `observability/otelcol`, `observability/traces`,
+    `openshift/mustgather` `ossm`, `ovn-kubernetes`, `tekton` (OCP).
 
     The tools listed below reflect the default configuration. The actual set of
     available tools depends on configuration — toolsets can be enabled or disabled,
     and individual tools within a toolset can be filtered using allow/deny lists.
-    See [Tool Filtering](https://github.com/openshift/openshift-mcp-server/blob/release-0.2.0/docs/configuration.md#tool-filtering) for details.
-version: latest
+    See [Tool Filtering](https://github.com/openshift/openshift-mcp-server/blob/release-0.4/docs/configuration.md#tool-filtering) for details.
+version: 0.4
 transports:
     - http
     - sse
@@ -236,9 +239,9 @@ tools:
       accessType: read_only
       parameters: []
 artifacts:
-    - uri: oci://registry.redhat.io/openshift-mcp-tech-preview/openshift-mcp-server-rhel9:0.3
-      createTimeSinceEpoch: "1777874265000"
-      lastUpdateTimeSinceEpoch: "1777874266000"
+    - uri: oci://registry.redhat.io/openshift-mcp-tech-preview/openshift-mcp-server-rhel9:0.4
+      createTimeSinceEpoch: "1785344615000"
+      lastUpdateTimeSinceEpoch: "1785344616000"
 runtimeMetadata:
     defaultArgs:
         - --config
@@ -286,4 +289,4 @@ customProperties:
         metadataType: MetadataStringValue
         string_value: ""
 createTimeSinceEpoch: "1753228800000"
-lastUpdateTimeSinceEpoch: "1777874266000"
+lastUpdateTimeSinceEpoch: "1785344616000"


### PR DESCRIPTION
## Summary
- Cherry-pick of 6dd4731 (`chore: update ocp mcp version to 0.4 (#190) (#191)`) from `main` to `rhoai-3.5`

## Test plan
- [ ] Verify OCP MCP server version updated to 0.4 in catalog output
- [ ] CI passes on rhoai-3.5 branch

🤖 Generated with [Claude Code](https://claude.ai/code)